### PR TITLE
Update NuGet.Config to use Telerik's v3 NuGet server

### DIFF
--- a/src/NuGet.Config
+++ b/src/NuGet.Config
@@ -8,7 +8,7 @@
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
 	
 	<!-- Telerik NuGet v3 server (currently beta) -->
-	<add key="Telerik" value="https://nuget.telerik.com/v3/index.json" />
+	<add key="Telerik" value="https://nuget.telerik.com/v3/index.json"  protocolVersion="3"/>
 	
 	<!-- Telerik NuGet v2 server -->
     <!--<add key="Telerik" value="https://nuget.telerik.com/nuget" />-->

--- a/src/NuGet.Config
+++ b/src/NuGet.Config
@@ -1,9 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
+    <!-- Clears any locally defined package sources (i.e. cleans up VS2019 sources) -->
     <clear/>
+	
+	<!-- NuGet.org feed -->
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-    <add key="Telerik" value="https://nuget.telerik.com/nuget" />
+	
+	<!-- Telerik NuGet v3 server (currently beta) -->
+	<add key="Telerik" value="https://nuget.telerik.com/v3/index.json" />
+	
+	<!-- Telerik NuGet v2 server -->
+    <!--<add key="Telerik" value="https://nuget.telerik.com/nuget" />-->
   </packageSources>
   <packageSourceCredentials>
     <Telerik>


### PR DESCRIPTION
Changed Telerik NuGet server to new v3 version.

v2: `nuget.telerik.com/nuget`
v3: `nuget.telerik.com/v3/index.json`