### PR TITLE
fix: use dotnet msbuild instead of MSBuild@1 in WinUI Azure Pipelines job

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -275,26 +275,22 @@ jobs:
   - powershell: dotnet restore $(winuiProjectPath) --configfile $(nugetConfigPath)
     displayName: 'Restore NuGet Packages'
 
-  - task: MSBuild@1
+  # Use 'dotnet msbuild' instead of MSBuild@1 so that the MSBuild bundled with the
+  # .NET 10 SDK is used. MSBuild@1 invokes VS 2022's standalone MSBuild (17.x), which
+  # cannot resolve the Microsoft.NET.Sdk because .NET SDK 10.0.300 requires MSBuild 18.0+.
+  - powershell: dotnet msbuild $(winuiProjectPath) /t:Restore /p:Platform=x64 /p:Configuration=Release /p:RestorePackages=true /p:RestoreRIDs=true /p:RestoreProjectStyle=PackageReference
     displayName: 'Restore RIDs'
-    inputs:
-      solution: '$(winuiProjectPath)'
-      platform: x64
-      configuration: Debug
-      msbuildVersion: '18.0.0'
-      msbuildArguments: '/t:Restore /p:Configuration=Release /p:RestorePackages=true /p:RestoreRIDs=true /p:RestoreProjectStyle=PackageReference'
 
-  - task: MSBuild@1
+  - powershell: >
+      dotnet msbuild $(winuiProjectPath)
+      /p:Platform=x64
+      /p:Configuration=Debug
+      /p:AppxBundlePlatforms="x64|arm64"
+      /p:UapAppxPackageBuildMode=CI
+      /p:AppxBundle=Never
+      /p:GenerateAppxPackageOnBuild=false
+      /p:AppxPackageSigningEnabled=false
     displayName: 'Build and Create MSIX'
-    inputs:
-      solution: '$(winuiProjectPath)'
-      platform: x64
-      configuration: Debug
-      msbuildArguments: '/p:AppxBundlePlatforms="x64|arm64" 
-                         /p:UapAppxPackageBuildMode=CI 
-                         /p:AppxBundle=Never 
-                         /p:GenerateAppxPackageOnBuild=false
-                         /p:AppxPackageSigningEnabled=false'
     env:
       TELERIK_LICENSE: $(MY_TELERIK_LICENSE_KEY)
 


### PR DESCRIPTION
## Problem

The `BuildWinUI` job was failing with `Could not resolve SDK "Microsoft.NET.Sdk"` because of a mismatch between two separate MSBuild installations on the hosted agent:

- `MSBuild@1` invokes **Visual Studio 2022's standalone MSBuild (v17.14)**
- .NET SDK `10.0.300` (installed via `UseDotNet@2`) requires **MSBuild 18.0+** to resolve `Microsoft.NET.Sdk`

VS 2022's MSBuild has no knowledge of the .NET 10 SDK paths, so the SDK resolver fails entirely. The `msbuildVersion: '18.0.0'` option on the Restore RIDs step was also ineffective -- MSBuild 18 is not installed on `windows-latest` agents (that requires VS 2025), so the task silently fell back to 17.14.

## Fix

Both `MSBuild@1` steps in the `BuildWinUI` job are replaced with `dotnet msbuild` commands. Calling `dotnet msbuild` routes through the .NET CLI, which invokes the **MSBuild bundled inside the .NET 10 SDK** (18.0+) rather than VS's copy. All original MSBuild properties (`/p:Platform`, `/p:AppxBundlePlatforms`, `/p:UapAppxPackageBuildMode`, etc.) are preserved exactly.